### PR TITLE
Fixed command for StartComponentCleanup

### DIFF
--- a/manufacture/desktop/clean-up-the-winsxs-folder.md
+++ b/manufacture/desktop/clean-up-the-winsxs-folder.md
@@ -46,7 +46,7 @@ If you choose to run this task, the task will have a 1 hour timeout and may not 
 3.  Under **Selected Item**, click **Run**
 
     ```
-    **schtasks.exe /Run /TN "\\Microsoft\\Windows\\Servicing\\StartComponentCleanup"**
+    schtasks.exe /Run /TN "\Microsoft\Windows\Servicing\StartComponentCleanup"
     ```
     > [!NOTE]
     > The StartComponentCleanup task can also be started from the command line.


### PR DESCRIPTION
The correct command does not require escape characters. The command mentioned in the Technet article below works perfectly, while the original command in the article gives the following error.

```ERROR: The filename, directory name, or volume label syntax is incorrect.```