### PR TITLE
Remove noise from example

### DIFF
--- a/customize/desktop/unattend/microsoft-windows-unattendedjoin-identification-joinworkgroup.md
+++ b/customize/desktop/unattend/microsoft-windows-unattendedjoin-identification-joinworkgroup.md
@@ -62,13 +62,7 @@ The following XML output shows how to set the identification settings.
 
 ```
 <Identification>
-   <Credentials>
-      <Domain>fabrikam.com</Domain>
-      <Password>MyPassword</Password>
-      <Username>MyUserName</Username>
-   </Credentials>
    <JoinWorkgroup>MyWorkgroup</JoinWorkgroup>
-   <MachinePassword>ComputerPassword</MachinePassword>
 </Identification>
 ```
 


### PR DESCRIPTION
When joining a workgroup, you don't need the credential info, right?