### PR TITLE
Add OpenSSH (Beta) to list of v2 FODs

### DIFF
--- a/manufacture/desktop/features-on-demand-v2--capabilities.md
+++ b/manufacture/desktop/features-on-demand-v2--capabilities.md
@@ -82,7 +82,14 @@ Use DISM to add or remove capabilities:
 |-----------|-------------------------------------------------------------------------|
 | NetFx3    | .NET 3.x Framework, a software framework required by many applications. |
 
- 
+
+### <span id="OPENSSH"></span><span id="openssh"></span> OpenSSH (Beta)
+
+| Component             | Description                                                            |
+|-----------------------|------------------------------------------------------------------------|
+| OpenSSH Client (Beta) | The beta release of an OpenSSH client for remoting and authentication. |
+| OpenSSH Server (Beta) | The beta release of an OpenSSH server for remoting and authentication. |
+
 
 ### <span id="language_capabilities"></span><span id="Language_capabilities"></span> Language capabilities
 


### PR DESCRIPTION
Tried my best to follow the formatting of the file. Gave as much detail as provided by NetFx3 (which is to say, very little), but if you want to add a link to our project (where we have a wiki, more info, etc.), that's fine. 

At some point we need to come back here when our OpenSSH port exits beta to remove the beta tag.