### PR TITLE
Fix for ACPITABL.dat deployment

### DIFF
--- a/manufacture/iot/add-a-driver-to-an-image.md
+++ b/manufacture/iot/add-a-driver-to-an-image.md
@@ -73,10 +73,12 @@ For example, review the list of drivers in the file: \\IoT-ADK-AddonKit\\Source-
                 <inf source="iaiogpio.inf" />
                 <files>
                     <file source="iaiogpio.sys" destinationDir="$(runtime.drivers)" name="iaiogpio.sys" />
-                    <file source="ACPITABL.dat" destinationDir="$(runtime.system32)" name="ACPITABL.dat" />
                 </files>
             </driver>
         </drivers>
+        <files>
+            <file source="ACPITABL.dat" destinationDir="$(runtime.system32)" name="ACPITABL.dat" />
+        </files>
     </identity>
     ```
 


### PR DESCRIPTION
In the new wm.xml driver package definition files, additional files mustn't be added inside the <driver></driver> tag anymore, but outside in a separate <files></files> tag.