### PR TITLE
Update sysprep--generalize--a-windows-installation.md

### DIFF
--- a/manufacture/desktop/sysprep--generalize--a-windows-installation.md
+++ b/manufacture/desktop/sysprep--generalize--a-windows-installation.md
@@ -14,35 +14,35 @@ ms.technology: windows-oem
 # Sysprep (Generalize) a Windows installation
 
 
-To deploy a Windows image to different PCs, you have to first generalize the image to remove computer-specific information such as device drivers and the computer security identifier (SID). You can either use [sysprep](sysprep--system-preparation--overview.md) or an [unattend](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/) answer file to generalize your image and make it ready for deployment.
+To deploy a Windows image to different PCs, you have to first generalize the image to remove computer-specific information such as the computer security identifier (SID). You can either use [Sysprep](sysprep--system-preparation--overview.md) by itself or Sysprep with an [unattend](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/) answer file to generalize your image and make it ready for deployment.
 
 ##  Generalizing a Windows installation
 
 When you generalize a Windows image, Windows Setup processes settings in the [generalize](generalize.md) configuration pass. Even if you're capturing an image that's going to be deployed to a PC with similar hardware, you still have to generalize the Windows installation to remove unique PC-specific information from a Windows installation, which allows you to safely reuse your image.
 
-When you generalize an image, Windows replaces the computer SID only on the operating system volume where you ran sysprep. If a single computer has multiple operating systems, you must run **Sysprep** on each image individually.
+When you generalize an image, Windows replaces the computer SID only on the operating system volume where you ran Sysprep. If a single computer has multiple operating systems, you must run **Sysprep** on each image individually.
 
-If you're generalizing Windows Server that has Remote Authentication Dial-In User Service (RADIUS) clients or remote RADIUS server groups defined in the Network Policy Server (NPS) configuration, you should remove this information before you deploy it to a different computer. For more information, see [Prepare a Network Policy Server (NPS) for Imaging](prepare-a-network-policy-server--nps--for-imaging.md).
+If you're generalizing a Windows Server installation that has Remote Authentication Dial-In User Service (RADIUS) clients or remote RADIUS server groups defined in the Network Policy Server (NPS) configuration, you should remove this information before you deploy it to a different computer. For more information, see [Prepare a Network Policy Server (NPS) for Imaging](prepare-a-network-policy-server--nps--for-imaging.md).
 
-### Prevent sysprep from removing drivers
+### Prevent Sysprep from removing the record of installed devices
 
-When you set up a Windows PC, Windows Setup installs drivers for any detected devices. By default, Windows Setup removes these drivers when you generalize the system, and the drivers have to be reinstalled when you deploy the image. 
+When you set up a Windows PC, Windows Setup sets up any detected devices.
 
-If you're deploying an image to computers that have the same hardware and devices as the original PC, you can keep these drivers on the computer during system generalization by using an unattend file with Microsoft-Windows-PnPSysprep | `PersistAllDeviceInstalls` set to **true**. For more information about **Sysprep**-related Windows unattend components, see the [Unattended Windows Setup Reference for Microsoft-Windows-PnpSysprep](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-pnpsysprep).
+If you're deploying an image to computers that have identical hardware and devices as the original PC, you can keep the record of these device installations on the computer during system generalization by using an unattend file with Microsoft-Windows-PnPSysprep | `PersistAllDeviceInstalls` set to **true**. For more information about **Sysprep**-related Windows unattend components, see the [Unattended Windows Setup Reference for Microsoft-Windows-PnpSysprep](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-pnpsysprep).
 
 ### Limits on how many times you can run Sysprep
 
-You can run the **Sysprep** command up to 8 times on a single Windows image. After running Sysprep 8 times, you must recreate your Windows image. In previous versions of Windows, you could use the `SkipRearm` answer file setting to reset the Windows Product Activation clock when running sysprep. If you are using a volume licensing key or a retail product key, you don't have to use `SkipRearm` because Windows is automatically activated. 
+You can run the **Sysprep** command up to 8 times on a single Windows image. After running Sysprep 8 times, you must recreate your Windows image. In previous versions of Windows, you could use the `SkipRearm` answer file setting to reset the Windows Product Activation clock when running Sysprep. If you are using a volume licensing key or a retail product key, you don't have to use `SkipRearm` because Windows is automatically activated. 
 
 
-### Microsoft Store Apps
+### Microsoft Store apps
 
-Updating your Microsoft Store apps before generalizing a Windows image will cause Sysprep to fail. `Sysprep /generalize` requires that all apps are provisioned for all users, however, when you update an app from the Microsoft Store, that app becomes tied to the user account. The following error appears in the sysprep log files (%WINDIR%\\System32\\Sysprep\\Panther):
+Installing new Microsoft Store apps or updating your existing Microsoft Store apps before generalizing a Windows image will cause Sysprep to fail. `Sysprep /generalize` requires that all apps are provisioned for all users; however, when you update an app from the Microsoft Store, that app becomes tied to the current user account. The following error appears in the Sysprep log files (located at %WINDIR%\\System32\\Sysprep\\Panther):
 
 `<package name> was installed for a user, but not provisioned for all users. This package will not function properly in the sysprep image.`
 
 
-Instead of using the Microsoft Store to update your apps, you should sideload updates to your line-of-business apps, or have end-users update their apps by using the Microsoft Store on their destination PCs. If Microsoft Store access in a managed environment is disabled by an IT administrator, end-users will not be able to update the Microsoft Store apps.
+Instead of using the Microsoft Store to update your apps, you should sideload updates to your line-of-business apps, provision offline-licensed Microsoft Store for Business apps for all users, or have end-users update their apps by using the Microsoft Store on their destination PCs. If Microsoft Store access in a managed environment is disabled by an IT administrator, end-users will not be able to update the Microsoft Store apps.
 
 For more information about sideloading line-of-business Microsoft Store apps, see [Sideload Apps with DISM](sideload-apps-with-dism-s14.md) and [Customize the Start Screen](customize-the-start-screen.md).
 
@@ -51,13 +51,13 @@ For more information about sideloading line-of-business Microsoft Store apps, se
 
 ### Generalize from Audit Mode
 
-To generalize an image, you have to first boot into Audit Mode. You can do boot into Audit Mode using unattend or from OOBE. You can read about the different ways of booting into audit mode at [Boot Windows to audit mode or OOBE](boot-windows-to-audit-mode-or-oobe.md).
+To generalize an image, you have to first boot into Audit Mode. You can boot into Audit Mode using an unattend file or from the Out-Of-Box Experience (OOBE) screen. You can read about the different ways of booting into Audit Mode at [Boot Windows to Audit Mode or OOBE](boot-windows-to-audit-mode-or-oobe.md).
 
-1. Boot a PC into Audit Mode. When Windows boots into Audit Mode, **System Preparation Tool** will appear on the desktop. Leave the **System Preparation Tool** window open. 
+1. Boot a PC into Audit Mode. When Windows boots into Audit Mode, **System Preparation Tool** will appear on the desktop. You can choose to either close the **System Preparation Tool** window or allow it to remain open.
 
-2. Customize Windows by adding drivers, changing settings, and installing programs.
+2. Customize Windows by adding drivers, changing settings, and installing programs.  Do not install any Microsoft Store apps using the Microsoft Store.
 
-3. Run sysprep.
+3. Run Sysprep.
 
     - If the **System Preparation Tool** window is still open, click **Generalize**, click **Shutdown**, and then click **OK** to generalize the image and shut down the PC.
 
@@ -76,7 +76,7 @@ To generalize an image, you have to first boot into Audit Mode. You can do boot 
 
 4.  After the computer shuts down, [capture your image with DISM](capture-images-of-hard-disk-partitions-using-dism.md).
 
-5.  Deploy this image to a reference computer. When the reference computer boots, it displays the Out-Of-Box Experience (OOBE) screen.
+5.  Deploy this image to a reference computer. When the reference computer boots, it displays the OOBE screen.
 
 ### Generalize using unattend
 

--- a/manufacture/desktop/sysprep--generalize--a-windows-installation.md
+++ b/manufacture/desktop/sysprep--generalize--a-windows-installation.md
@@ -14,9 +14,9 @@ ms.technology: windows-oem
 # Sysprep (Generalize) a Windows installation
 
 
-To deploy a Windows image to different PCs, you have to first generalize the image to remove computer-specific information such as the computer security identifier (SID). You can either use [Sysprep](sysprep--system-preparation--overview.md) by itself or Sysprep with an [unattend](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/) answer file to generalize your image and make it ready for deployment.
+To deploy a Windows image to different PCs, you have to first generalize the image to remove computer-specific information such as installed drivers and the computer security identifier (SID). You can either use [Sysprep](sysprep--system-preparation--overview.md) by itself or Sysprep with an [unattend](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/) answer file to generalize your image and make it ready for deployment.
 
-##  Generalizing a Windows installation
+##  Generalize a Windows installation
 
 When you generalize a Windows image, Windows Setup processes settings in the [generalize](generalize.md) configuration pass. Even if you're capturing an image that's going to be deployed to a PC with similar hardware, you still have to generalize the Windows installation to remove unique PC-specific information from a Windows installation, which allows you to safely reuse your image.
 
@@ -24,11 +24,11 @@ When you generalize an image, Windows replaces the computer SID only on the oper
 
 If you're generalizing a Windows Server installation that has Remote Authentication Dial-In User Service (RADIUS) clients or remote RADIUS server groups defined in the Network Policy Server (NPS) configuration, you should remove this information before you deploy it to a different computer. For more information, see [Prepare a Network Policy Server (NPS) for Imaging](prepare-a-network-policy-server--nps--for-imaging.md).
 
-### Prevent Sysprep from removing the record of installed devices
+### Prevent Sysprep from removing installed devices
 
-When you set up a Windows PC, Windows Setup sets up any detected devices.
+When you set up a Windows PC, Windows Setup configures all detected devices. Generalizing a Windows installation uninstalls configured devices, but does not remove device drivers from the PC.
 
-If you're deploying an image to computers that have identical hardware and devices as the original PC, you can keep the record of these device installations on the computer during system generalization by using an unattend file with Microsoft-Windows-PnPSysprep | `PersistAllDeviceInstalls` set to **true**. For more information about **Sysprep**-related Windows unattend components, see the [Unattended Windows Setup Reference for Microsoft-Windows-PnpSysprep](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-pnpsysprep).
+If you're deploying an image to computers that have identical hardware and devices as the original PC, you can keep devices installed on the computer during system generalization by using an unattend file with Microsoft-Windows-PnPSysprep | `PersistAllDeviceInstalls` set to **true**. For more information about **Sysprep**-related Windows unattend components, see the [Unattended Windows Setup Reference for Microsoft-Windows-PnpSysprep](https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-pnpsysprep).
 
 ### Limits on how many times you can run Sysprep
 
@@ -37,10 +37,9 @@ You can run the **Sysprep** command up to 8 times on a single Windows image. Aft
 
 ### Microsoft Store apps
 
-Installing new Microsoft Store apps or updating your existing Microsoft Store apps before generalizing a Windows image will cause Sysprep to fail. `Sysprep /generalize` requires that all apps are provisioned for all users; however, when you update an app from the Microsoft Store, that app becomes tied to the current user account. The following error appears in the Sysprep log files (located at %WINDIR%\\System32\\Sysprep\\Panther):
+Installing new Microsoft Store apps or updating your existing Microsoft Store apps before generalizing a Windows image will cause Sysprep to fail. `Sysprep /generalize` requires that all apps are provisioned for all users; however, when you update an app from the Microsoft Store, that app becomes tied to the logged in user account. The following error appears in the Sysprep log files (located at %WINDIR%\\System32\\Sysprep\\Panther):
 
 `<package name> was installed for a user, but not provisioned for all users. This package will not function properly in the sysprep image.`
-
 
 Instead of using the Microsoft Store to update your apps, you should sideload updates to your line-of-business apps, provision offline-licensed Microsoft Store for Business apps for all users, or have end-users update their apps by using the Microsoft Store on their destination PCs. If Microsoft Store access in a managed environment is disabled by an IT administrator, end-users will not be able to update the Microsoft Store apps.
 


### PR DESCRIPTION
--Changed a few instances of "sysprep" to "Sysprep"

--Made a correction in the article that is a common myth.  Contrary to what the article currently says, Sysprep generalization does *not* remove device drivers -- at all.  In fact, device drivers can be injected via PNPUTIL and will still be in the driver store after Sysprep generalization.  If you don't believe it, try it yourself: inject a driver using PNPUTIL, run Sysprep generalization, and then check PNPUTIL after generalization.  You will see that the driver is still available.

What Sysprep actually does is remove device *installations*.  For example, imagine that you have a USB flash drive installed before running Sysprep generalization.  Sysprep will remove the record that this specific USB flash drive was ever installed; it will *not* remove the driver for the USB flash drive.  That's why the device can still be installed after Sysprep generalization without installing an associated driver.

Notice that the name of the unattend setting is called "PersistAllDeviceInstalls."  It's named that because it preserves device installations, not drivers.  Sysprep generalization *already* does not remove drivers.  Again, I know this is confusing, but it's been like this for 10 years.  I'd like to go ahead and eliminate this confusion once and for all with exacting clarification.

--Added wording that the IT professional actually *can* include new and updated Microsoft Store apps so long as (a) the apps are obtained from the Windows Store for Business as APPX packages, (b) the offline license for the app is obtained, and (c) PowerShell is used to provision the app for all users.  However, as the article correctly suggests, the Microsoft Store itself cannot currently be used to do this.  Instead, a one-time manual process for the IT professional is required.  There should probably be a link on this page on how to do this.  I wouldn't mind writing it if it would be published.  Is there interest in this?

--Changed instances of "audit mode" to "Audit Mode"

--Clarified that the Sysprep window can safely be closed or left open; it does not matter.  In fact, the article already later mentions this, so this change is just making the article consistent.

--Changed the first instance of "OOBE" to "Out-Of-Box-Experience (OOBE)" to clarify what that stands for earlier in the article