### PR TITLE
Create ignorecscompliancecheck.md

### DIFF
--- a/customize/power-settings/ignorecscompliancecheck.md
+++ b/customize/power-settings/ignorecscompliancecheck.md
@@ -1,0 +1,51 @@
+---
+title: IgnoreCsComplianceCheck
+description: Use to disable the default OS requirement of having non-rotational media in a Modern Standby system.
+MSHAttr:
+- 'PreferredSiteName:MSDN'
+- 'PreferredLib:/library/windows/hardware'
+ms.assetid: B96E275A-C2F6-4471-8077-93C829505006
+ms.author: chcurlet
+ms.date: 1/25/2018
+ms.topic: article
+ms.prod: windows-hardware
+ms.technology: windows-oem
+---
+# IgnoreCsComplianceCheck
+
+Use to disable the default OS requirement of having non-rotational media in a Modern Standby system.
+
+## <span id="Aliases_and_setting_visibility"></span><span id="aliases_and_setting_visibility"></span><span id="ALIASES_AND_SETTING_VISIBILITY"></span>Aliases and setting visibility
+
+* **Windows Provisioning:** `IgnoreCsComplianceCheck`
+* **Hidden setting:** Yes
+
+## <span id="Values"></span><span id="values"></span><span id="VALUES"></span>Values
+
+<table>
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p>1</p></td>
+<td><p>Disable the check requiring non-rotational media in a Modern Standby system.</p>
+</td>
+</tr>
+<tr class="even">
+<td><p>0</p></td>
+<td><p>Enable the check requiring non-rotational media in a Modern Standby system (default).</p></td>
+</tr>
+</tbody>
+</table>
+
+## <span id="Applies_to"></span><span id="applies_to"></span><span id="APPLIES_TO"></span>Applies to
+
+Available in Windows 10, RTM RS4 build and later versions of Windows.


### PR DESCRIPTION
Document how to change the IgnoreCsComplianceCheck ppkg flag. Allows OEMs/IHVs to override the default OS requirement of having non-rotational media in a Modern Standby system.