### PR TITLE
fix bold text decoration for Unattend folder location

### DIFF
--- a/manufacture/desktop/boot-windows-to-audit-mode-or-oobe.md
+++ b/manufacture/desktop/boot-windows-to-audit-mode-or-oobe.md
@@ -78,7 +78,7 @@ If a password-protected screen saver starts when you are in audit mode, you cann
 
     where *&lt;image\_index&gt;* is the number of the selected image on the .wim file.
 
-3.  Copy the new answer file to the **C:\\test\\offline\\Windows\\Panther\\Unattend folder**.
+3.  Copy the new answer file to the **C:\\test\\offline\\Windows\\Panther\\Unattend** folder.
 
 4.  Commit the changes, and then unmount the image. For example:
 


### PR DESCRIPTION
Current bolding makes it appear as if the location is `Unattend folder`. Fixed bold text.