### PR TITLE
Update profile-wpr.md

### DIFF
--- a/test/wpt/profile-wpr.md
+++ b/test/wpt/profile-wpr.md
@@ -71,6 +71,7 @@ Represents a collection of problem categories and collectors elements.
 | :---------------------------------------- | :----------------------------------------------------- | :------------------- |
 | [ProblemCategories](problemcategories.md) | Represents a collection of problem categories.         | Required, exactly 1. |
 | [Collectors](collectors.md)               | Represents a collection of collectors for the profile. | Required, exactly 1. |
+| [TraceMergeProperties](tracemergeproperties.md) | Represents a collection of trace merge properites. | Optional, exactly 1. |
 
 
 ### Parent Elements


### PR DESCRIPTION
TraceMergeProperties needs to be inside the profile element. 
TraceMergeProperties that is currently the child of <WindowsPerformanceRecorder> element. It is schematically correct but it doesn't get picked up from wpr profile processing engine because that place is only for the default properties for built-in profile.