### PR TITLE
This change updates the Cortana and Bluetooth feature information

### DIFF
--- a/manufacture/iot/integrating-bluetooth-audio.md
+++ b/manufacture/iot/integrating-bluetooth-audio.md
@@ -1,0 +1,19 @@
+---
+author: joslobo
+Description: 'Integrating Bluetooth Audio on IoT'
+title: 'Integrating Bluetooth Audio Features'
+ms.author: joslobo
+ms.date: 08/29/2018
+ms.topic: article
+ms.prod: windows-hardware
+ms.technology: windows-oem
+---
+
+# Integrating A2DP Audio on IoT
+
+Windows 10 Iot Core supports the Bluetooth A2DP audio profile.  When creating a custom image for your platform, you may add IOT\_BLUETOOTH\_A2DP\_SINK so your device can receive audio via Bluetooth from another device, or IOT\_BLUETOOTH\_A2DP\_SOURCE to support audio playback via Bluetooth to another device.  For example, a smart speaker device would include the IOT\_BLUETOOTH\_A2DP\_SINK feature. Likewise, a portable music player would include the IOT\_BLUETOOTH\_A2DP\_SOURCE feature.  
+
+It is possible create dual role devices by including both IOT\_BLUETOOTH\_A2DP\_SINK and IOT\_BLUETOOTH\_A2DP\_SOURCE features within a single device.  Dual role devices will pair and function with another single role device.  However, if a dual role device pairs with another dual role device, the Windows IoT Bluetooth implementation will favor one role over the other. By default, the preferred role is A2DP-Source. So, for example, when a dual role IoT Device pairs to another dual role device, the first device will behave as if it only supports A2DP-Source.
+
+The role preference may be switched through the IoTSettings tool.  Note that when switching roles, a reboot is required and devices will need to be re-paired.  To avoid the reboot and re-pair situation, it is recommended that dual mode devices choose a specific role preference as a [Runtime Customization](https://docs.microsoft.com/en-us/windows/iot-core/build-your-image/oscustomizations) in the oemcustomizations.cmd file.
+

--- a/manufacture/iot/iot-core-feature-list.md
+++ b/manufacture/iot/iot-core-feature-list.md
@@ -43,8 +43,8 @@ When creating images for your device, determine which features are required for 
 | **IOT\_FFU\_FLASHMODE** | Adds flashing mode support so that the device can be flashed using ffutool. Currently supported for arm only. This is new in Windows 10, version 1803 |
 | **IOT\_MTP** | Adds Media transfer protocol support. See [MTP](https://docs.microsoft.com/windows/iot-core/connect-your-device/mtp). This is new in Windows 10, version 1803 |
 | **IOT\_MIRACAST\_RX_APP** | Adds Connect App that supports Miracast receive feature. Note that the underlying hw/drivers should support Miracast for this app to work. Currently supported for arm only. This is new in Windows 10, version 1803 |
-| **IOT\_BLUETOOTH\_A2DP\_SINK** | Adds ability to receive and play A2DP audio from an external device to the IoT device. This is new in Windows 10 1809 |
-| **IOT\_BLUETOOTH\_A2DP\_SOURCE** | Adds ability to play audio to an external device.  This was implicitly included in Windows 10, version 1803, but must be explicitly specified beginning with Windows 10, version 1809 |
+| **IOT\_BLUETOOTH\_A2DP\_SINK** | Adds ability to receive and play A2DP audio from an external device to the IoT device. This is new in Windows 10, 1809. See [Integrating Bluetooth Audio](integrating-bluetooth-audio.md). |
+| **IOT\_BLUETOOTH\_A2DP\_SOURCE** | Adds ability to play audio to an external device.  This was implicitly included in Windows 10, version 1803, but must be explicitly specified beginning with Windows 10, version 1809.  See [Integrating Bluetooth Audio](integrating-bluetooth-audio.md). |
 | **IOT\_BLUETOOTH\_HFP\_AUDIOGATEWAY** | Adds Bluetooth Handsfree-Profile AudioGateway role. This is new in Windows 10, version 1809 |
 
 ### Settings

--- a/manufacture/iot/iot-core-feature-list.md
+++ b/manufacture/iot/iot-core-feature-list.md
@@ -43,7 +43,9 @@ When creating images for your device, determine which features are required for 
 | **IOT\_FFU\_FLASHMODE** | Adds flashing mode support so that the device can be flashed using ffutool. Currently supported for arm only. This is new in Windows 10, version 1803 |
 | **IOT\_MTP** | Adds Media transfer protocol support. See [MTP](https://docs.microsoft.com/windows/iot-core/connect-your-device/mtp). This is new in Windows 10, version 1803 |
 | **IOT\_MIRACAST\_RX_APP** | Adds Connect App that supports Miracast receive feature. Note that the underlying hw/drivers should support Miracast for this app to work. Currently supported for arm only. This is new in Windows 10, version 1803 |
-
+| **IOT\_BLUETOOTH\_A2DP\_SINK** | Adds ability to receive and play A2DP audio from an external device to the IoT device. This is new in Windows 10 1809 |
+| **IOT\_BLUETOOTH\_A2DP\_SOURCE** | Adds ability to play audio to an external device.  This was implicitly included in Windows 10, version 1803, but must be explicitly specified beginning with Windows 10, version 1809 |
+| **IOT\_BLUETOOTH\_HFP\_AUDIOGATEWAY** | Adds Bluetooth Handsfree-Profile AudioGateway role. This is new in Windows 10, version 1809 |
 
 ### Settings
 
@@ -72,8 +74,8 @@ When creating images for your device, determine which features are required for 
 | **IOT\_TOOLKIT**                | Includes developer tools such as: Kernel Debug components, FTP, Network Diagnostics, basic device portal, and XPerf. This also relaxes the firewall rules and enables various ports.                                                                                           |
 | **IOT\_WEBB\_EXTN**             | Enables IOTCore-specific extensions to the Windows Device Portal. The basic device portal is included in the IoT Toolkit.  |
 | **IOT\_NANORDPSERVER**          | Adds [Remote Display packages](https://docs.microsoft.com/windows/iot-core/manage-your-device/RemoteDisplay). Supported starting with Windows 10, version 1607. Note: Remote Display is prerelease software intended for development and training purposes only.                      |
-| **IOT\_CORTANA**                | Adds Cortana feature. Requires **IOT\_APPLICATIONS** feature. This is new in Windows 10, version 1703.       |
-| **IOT\_CORTANA\_OBSCURELAUNCH** | Enables running Cortana application on boot. This add-on causes Cortana to run in the background resulting in better response time for Cortana. This is new in Windows 10, version 1703. |
+| ~~IOT\_CORTANA~~  (Deprecated)  | The Cortana application is no longer available as a feature in Windows 10, version 1809.  To build Cortana enabled applications on IoT please refer to [The Cortana Dev Center](http://www.aka.ms/cortanadevices).    |
+| ~~IOT\_CORTANA\_OBSCURELAUNCH~~ (Deprecated) | The Cortana application is no longer available as a feature in Windows 10, version 1809. To build Cortana enabled applications on IoT, please refer to [The Cortana Dev Center](http://www.aka.ms/cortanadevices). |
 | **IOT\_BERTHA**                 | Adds a sample app: "Bertha". This app provides basic version info and connectivity status.             |
 | **IOT\_UAP\_DEFAULTAPP**        | Adds a sample app, "Chucky". This app is similar to "Bertha".                              |
 | **IOT\_FTSER2K\_MAKERDRIVER**   | Adds the FTDI USB-to-Serial driver.                                                                                          |


### PR DESCRIPTION
Starting with RS5 version of Windows IoT Core, the Cortana application is no longer available as an option.  This change marks both as deprecated and recommends the user consult with the Cortana Dev Center.  

Starting in RS5 there are multiple, individual, Bluetooth features available for Windows IoT.  This change includes the new feature identifiers