### PR TITLE
Specify where DVL logs are expected.

### DIFF
--- a/test/hlk/testref/6ab6df93-423c-4af6-ad48-8ea1049155ae.md
+++ b/test/hlk/testref/6ab6df93-423c-4af6-ad48-8ea1049155ae.md
@@ -49,7 +49,7 @@ Before you run the test,, you must create a Driver Verification Log (DVL) by per
 
 2.  Run a utility that generates the DVL file.
 
-3.  Copy the DVL file from the computer that was used to create the DVL file to the test computer that is used when you run the Static Tools Logo Test.
+3.  Copy the DVL file from the computer that was used to create the DVL file to the test computer that is used when you run the Static Tools Logo Test.  The DVL file should be placed in [SystemDrive]\dvl - for example, C:\dvl.
 
 For more information about creating a Driver Verification Log file to include with your submission, see [Creating a Driver Verification Log](http://go.microsoft.com/fwlink/?LinkId=248552).
 


### PR DESCRIPTION
The Static Tools Logo test requires DVL files to be placed in a specific folder, but that isn't made explicit in the documentation as it stands today.  Updating to make that clear.