### PR TITLE
Update to Windows partition requirements section

### DIFF
--- a/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions.md
+++ b/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions.md
@@ -76,7 +76,7 @@ Each partition can have a maximum of 18 exabytes (~18.8 million terabytes) of sp
 -   **Windows partition**
     -   The partition must have at least 20 gigabytes (GB) of drive space for 64-bit versions, or 16 GB for 32-bit versions.
     -   The Windows partition must be formatted using the NTFS file format.
-    -   The Windows partition must have enough 10 GB of free space after the user has completed the Out Of Box Experience (OOBE).
+    -   The Windows partition must have enough free space after the user has completed the Out Of Box Experience (OOBE). Please refer to the OEM Policy Document for additional details.
 -   **Recovery tools partition**
 
     This partition must be at least 300 MB.


### PR DESCRIPTION
I’d strongly caution against documenting OEM policy outside of the OPD itself, for a number of reasons. I’d instead urge that this page make reference explicitly to the OEM Policy Document, so that the right audience seeks out the current and up-to-date requirement.