### PR TITLE
Update PowerShell examples to best practices

### DIFF
--- a/customize/enterprise/keyboardfilter-add-blocked-key-combinations.md
+++ b/customize/enterprise/keyboardfilter-add-blocked-key-combinations.md
@@ -16,13 +16,13 @@ ms.technology: windows-oem
 
 The following sample Windows PowerShell script uses the Windows Management Instrumentation (WMI) providers for Keyboard Filter to create three functions to configure Keyboard Filter so that Keyboard Filter blocks key combinations. It demonstrates several ways to use each function.
 
-The first function, `Enable-Predefine-Key`, blocks key combinations that are predefined for Keyboard Filter.
+The first function, `Enable-PredefinedKeyFilter`, blocks key combinations that are predefined for Keyboard Filter.
 
-The second function, `Enable-Custom-Key`, blocks custom key combinations by using the English key names.
+The second function, `Enable-CustomKeyFilter`, blocks custom key combinations by using the English key names.
 
-The third function, `Enable-Scancode`, blocks custom key combinations by using the keyboard scan code for the key.
+The third function, `Enable-ScancodeFilter`, blocks custom key combinations by using the keyboard scan code for the key.
 
-## Enable-rules.ps1
+## KeyFilter.psm1
 
 ```powershell
 #
@@ -39,13 +39,13 @@ The third function, `Enable-Scancode`, blocks custom key combinations by using t
     locally.
 #>
 param (
-    [String] $ComputerName
+    [string]$ComputerName
 )
 
 $CommonParams = @{"namespace"="root\standardcimv2\embedded"}
 $CommonParams += $PSBoundParameters
 
-function Enable-Predefined-Key($Id) {
+function Enable-PredefinedKeyFilter {
     <#
     .Synopsis
         Toggle on a Predefined Key keyboard filter Rule
@@ -54,26 +54,29 @@ function Enable-Predefined-Key($Id) {
         filter against key value "Id", and set that instance's "Enabled"
         property to 1/true.
     .Example
-        Enable-Predefined-Key "Ctrl+Alt+Del"
+        Enable-PredefinedKeyFilter "Ctrl+Alt+Del"
         Enable CAD filtering
-#>
+    #>
+    [Alias("Enable-Predefined-Key")] # The old name
+    [CmdletBinding()]
+    param([string]$Id)
 
     $predefined = Get-WMIObject -class WEKF_PredefinedKey @CommonParams |
-        where {
-            $_.Id -eq "$Id"
-        };
+        Where-Object {
+            $_.Id -eq $Id
+        }
 
     if ($predefined) {
-        $predefined.Enabled = 1;
-        $predefined.Put() | Out-Null;
-        Write-Host Enabled $Id
+        $predefined.Enabled = 1
+        $predefined.Put() | Out-Null
+        Write-Host "Enabled $Id"
     } else {
         Write-Error "$Id is not a valid predefined key"
     }
 }
 
 
-function Enable-Custom-Key($Id) {
+function Enable-CustomKeyFilter {
     <#
     .Synopsis
         Toggle on a Custom Key keyboard filter Rule
@@ -85,31 +88,33 @@ function Enable-Custom-Key($Id) {
         In the case that the Custom instance does not exist, add a new
         instance of WEKF_CustomKey using Set-WMIInstance.
     .Example
-        Enable-Custom-Key "Ctrl+V"
+        Enable-CustomKeyFilter "Ctrl+V"
         Enable filtering of the Ctrl + V sequence.
-#>
+    #>
+    [Alias("Enable-Custom-Key")] # The old name
+    [CmdletBinding()]
+    param([string]$Id)
 
     $custom = Get-WMIObject -class WEKF_CustomKey @CommonParams |
-        where {
+        Where-Object {
             $_.Id -eq "$Id"
-        };
+        }
 
     if ($custom) {
-# Rule exists.  Just enable it.
-        $custom.Enabled = 1;
-        $custom.Put() | Out-Null;
-        "Enabled Custom Filter $Id.";
-
+        # Rule exists.  Just enable it.
+        $custom.Enabled = 1
+        $custom.Put() | Out-Null
+        Write-Host ("Enabled Custom Filter $Id.")
     } else {
         Set-WMIInstance `
             -class WEKF_CustomKey `
             -argument @{Id="$Id"} `
             @CommonParams | Out-Null
-        "Added Custom Filter $Id.";
+        Write-Host ("Added Custom Filter $Id.")
     }
 }
 
-function Enable-Scancode($Modifiers, [int]$Code) {
+function Enable-ScancodeFilter {
     <#
     .Synopsis
         Toggle on a Scancode keyboard filter Rule
@@ -121,39 +126,46 @@ function Enable-Scancode($Modifiers, [int]$Code) {
         In the case that the Scancode instance does not exist, add a new
         instance of WEKF_Scancode using Set-WMIInstance.
     .Example
-        Enable-Scancode "Ctrl" 37
+        Enable-ScancodeFilter "Ctrl" 0x25
+        Enable filtering of the Ctrl + keyboard scancode 25 (base-16)
+        sequence.
+    .Example
+        Enable-ScancodeFilter "Ctrl" 37
         Enable filtering of the Ctrl + keyboard scancode 37 (base-10)
         sequence.
-#>
+    #>
+    [Alias("Enable-Scancode")] # The old name
+    [CmdletBinding()]
+    param([string]$Modifiers, [int]$Code)
 
     $scancode =
         Get-WMIObject -class WEKF_Scancode @CommonParams |
-            where {
+            Where-Object {
                 ($_.Modifiers -eq $Modifiers) -and ($_.Scancode -eq $Code)
             }
 
     if($scancode) {
         $scancode.Enabled = 1
         $scancode.Put() | Out-Null
-        "Enabled Custom Scancode {0}+{1:X4}" -f $Modifiers, $Code
+        Write-Host ("Enabled Custom Scancode {0}+{1:X4}" -f $Modifiers, $Code)
     } else {
         Set-WMIInstance `
             -class WEKF_Scancode `
             -argument @{Modifiers="$Modifiers"; Scancode=$Code} `
             @CommonParams | Out-Null
  
-        "Added Custom Scancode {0}+{1:X4}" -f $Modifiers, $Code
+        Write-Host ("Added Custom Scancode {0}+{1:X4}" -f $Modifiers, $Code)
     }
 }
 
 # Some example uses of the functions defined above.
-Enable-Predefined-Key "Ctrl+Alt+Del"
-Enable-Predefined-Key "Ctrl+Esc"
-Enable-Custom-Key "Ctrl+V"
-Enable-Custom-Key "Numpad0"
-Enable-Custom-Key "Shift+Numpad1"
-Enable-Custom-Key "%"
-Enable-Scancode "Ctrl" 37
+Enable-PredefinedKeyFilter "Ctrl+Alt+Del"
+Enable-PredefinedKeyFilter "Ctrl+Esc"
+Enable-CustomKeyFilter "Ctrl+V"
+Enable-CustomKeyFilter "Numpad0"
+Enable-CustomKeyFilter "Shift+Numpad1"
+Enable-CustomKeyFilter "%"
+Enable-ScancodeFilter "Ctrl" 37
 ```
 
 ## Related topics


### PR DESCRIPTION
1. Remove extra dashes and add "Filter" to the name so that it's clear that `Enable-PredefinedKeyFilter` actually _prevents_ the use of that key.
2. Clean up PowerShell slightly to remove unecessary `;` and use full command names instead of aliases