### PR TITLE
typo: Parition -> Partition

### DIFF
--- a/manufacture/mobile/iutool-error-codes.md
+++ b/manufacture/mobile/iutool-error-codes.md
@@ -1214,7 +1214,7 @@ The following are error codes from IUTool.exe. For more info, see [IUTool.exe: U
 <tr class="odd">
 <td><p>0x8018830E</p></td>
 <td><p>E_REMOVAL_PACKAGE_CANNOT_TARGET_BINARY_PARTITION</p></td>
-<td><p>This package is a removal package targeted to a binary parition Binary partition packages cannot be deleted.</p></td>
+<td><p>This package is a removal package targeted to a binary partition. Binary partition packages cannot be deleted.</p></td>
 </tr>
 <tr class="even">
 <td><p>0x8018830F</p></td>


### PR DESCRIPTION
The typo might exist as a product bug in the error message